### PR TITLE
docs: update opencode in tools page

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -24,8 +24,8 @@
   **使用门槛：** 中。通常作为底层能力，需通过 API 或集成工具调用，适合有工程搭建能力的开发者。<br>
   **适用场景：** 构建自定义的 AI 编程助手、进行大规模的代码自动转换或文档生成。
 - [OpenCode](https://opencode.ai)<br>
-  一款开源的终端 AI 编码助手。支持 GPT、Claude、Gemini、GLM 等多种模型；提供 Plan（仅分析）和 Build（实际修改）双模式；可集成到 VS Code、Cursor 等 IDE，并支持 MCP 扩展。分按量付费，Go 计划，自带模型三种付费模式。其中Go计划每月10\$（首月5\$），分每5h/周/月上限，不同模型可用额度不同，总体可适应中等强度开发。<br>
-  GitHub 仓库：[sst/opencode](https://github.com/sst/opencode)<br>
+  一款开源 AI coding agent。支持 GLM、Kimi、Mimo、Minimax、Qwen、DeepSeek 等模型；提供 Plan（仅分析）和 Build（实际修改）双模式；可集成到 VS Code、Cursor 等 IDE，并支持 MCP 扩展。分按量付费，Go 计划，自带模型三种付费模式。其中Go计划每月10\$（首月5\$），分每5h/周/月上限，不同模型可用额度不同，总体可适应中等强度开发。<br>
+  GitHub 仓库：[anomalyco/opencode](https://github.com/anomalyco/opencode)<br>
   **使用门槛：** 中低。需具备基础终端操作能力或通过 IDE 集成使用，配置模型较为灵活。<br>
   **适用场景：** 适合希望在终端或常用 IDE 中接入多种大模型进行中等强度日常开发与项目分析的开发者。
 


### PR DESCRIPTION
tools.md中OpenCode的github仓库链接发生变化，支持的模型种类亦发生变化，故作此更新